### PR TITLE
Extend "ElementType.Duplicate", Element.Location".

### DIFF
--- a/nodes/0.8.x/Element.Location.dyf
+++ b/nodes/0.8.x/Element.Location.dyf
@@ -1,4 +1,4 @@
-<Workspace Version="0.8.2.2392" X="108.149719091363" Y="186.645442473688" zoom="0.637154578399209" Name="Element.Location" Description="Returns the location of an element as an XYZ (or if it's line-based the start and end point of the line), along with some booleans to help filtering the results. Use this for some element types (e.g. walls or lines) that do not work with the built-in Get Family Instance Location node. " ID="0b59c4d8-afe4-4063-bf7e-2195fa33e8a9" Category="Clockwork.Revit.Elements.Element.Query">
+<Workspace Version="0.8.2.2392" X="-810.991792148763" Y="-102.302014787487" zoom="1.39028218019753" Name="Element.Location" Description="Returns the location of an element as an XYZ (or if it's line-based the start and end point of the line), along with some booleans to help filtering the results. Use this for some element types (e.g. walls or lines) that do not work with the built-in Get Family Instance Location node. " ID="0b59c4d8-afe4-4063-bf7e-2195fa33e8a9" Category="Clockwork.Revit.Elements.Element.Query">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Nodes.Function guid="0172cd21-9f9a-4382-82cb-a6341dcc77da" type="Dynamo.Nodes.Function" nickname="TurnIntoList" x="199" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
@@ -6,7 +6,7 @@
       <Name value="Turn Into List" />
       <Description value="Turns an element (or a nested list) into a flat list" />
       <Inputs>
-        <Input value="" />
+        <Input value="unknownItem" />
       </Inputs>
       <Outputs>
         <Output value="seq" />
@@ -15,24 +15,25 @@
     <Dynamo.Nodes.Symbol guid="467e3f8f-3faf-49fc-94c3-76b1b0c59c5e" type="Dynamo.Nodes.Symbol" nickname="Input" x="0" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
       <Symbol value="element" />
     </Dynamo.Nodes.Symbol>
-    <Dynamo.Nodes.Output guid="3ebf8af8-90b7-44f8-afdf-742ff53b9f65" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="3ebf8af8-90b7-44f8-afdf-742ff53b9f65" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="-13.753237059281" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="points" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="fe6d5941-e752-40bb-b243-e86bdd061ab9" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="83" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="fe6d5941-e752-40bb-b243-e86bdd061ab9" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="42.1780581895263" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="curveEndpoints" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="fef50bd5-ee46-46bb-bc91-c1d356b52c80" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="166" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="fef50bd5-ee46-46bb-bc91-c1d356b52c80" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="98.1093534383336" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="curves" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="9c5fe234-6333-42d1-8497-fa4ae9ff0a2d" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="250" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="9c5fe234-6333-42d1-8497-fa4ae9ff0a2d" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="154.040648687141" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="isPoint" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="21d34519-3cea-4d3f-b917-cbe99953d0f1" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="21d34519-3cea-4d3f-b917-cbe99953d0f1" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="209.971943935948" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="isCurve" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="bd3f39ee-762e-4a88-a57d-373694197124" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="628" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="seq[0];&#xA;seq[1];&#xA;seq[2];&#xA;seq[3];&#xA;seq[4];&#xA;seq[5];" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="bd3f39ee-762e-4a88-a57d-373694197124" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="551.355185870988" y="139.870950208536" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="seq[0];&#xA;seq[1];&#xA;seq[2];&#xA;seq[3];&#xA;seq[4];&#xA;seq[5];&#xA;seq[6];&#xA;seq[7];" ShouldFocus="false" />
     <DSIronPythonNode.PythonNode guid="f9cf6ebe-4cb6-43a4-b682-f29bf6633963" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="404" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" inputcount="1">
       <Script>import clr
+import math
 clr.AddReference('RevitAPI')
 from Autodesk.Revit.DB import *
 
@@ -47,6 +48,7 @@ ispoint = list()
 iscurve = list()
 curves = list()
 haslocation = list()
+angles, hasrotation = [], []
 
 for item in items:
 	try:
@@ -55,6 +57,7 @@ for item in items:
 		ispoint.append(True)
 		iscurve.append(False)
 		haslocation.append(True)
+		hasrotation.append(False)
 	except:
 		try:
 			loc = item.Location
@@ -66,12 +69,16 @@ for item in items:
 				ispoint.append(False)
 				iscurve.append(True)
 				haslocation.append(True)
+				hasrotation.append(False)
 			elif loc.ToString() == 'Autodesk.Revit.DB.LocationPoint':
 				# point-based elements
 				pointlist.append(loc.Point.ToPoint())
+				angles.append(math.degrees(loc.Rotation) )
 				ispoint.append(True)
 				iscurve.append(False)
+				angles.append
 				haslocation.append(True)
+				hasrotation.append(True)
 			else:
 				ispoint.append(False)
 				iscurve.append(False)
@@ -89,10 +96,16 @@ for item in items:
 				ispoint.append(False)
 				iscurve.append(False)
 				haslocation.append(False)
-OUT = (pointlist,curvepointlist,curves,ispoint,iscurve,haslocation)</Script>
+OUT = (pointlist,curvepointlist,curves,ispoint,iscurve,haslocation,angles, hasrotation)</Script>
     </DSIronPythonNode.PythonNode>
-    <Dynamo.Nodes.Output guid="f049edbf-dc90-4d9d-8d55-aec33858083d" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="416" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="f049edbf-dc90-4d9d-8d55-aec33858083d" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="265.903239184756" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="hasLocation" />
+    </Dynamo.Nodes.Output>
+    <Dynamo.Nodes.Output guid="14d49b05-5d40-4fbf-b0e4-71bfaaee0839" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="321.834534433563" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+      <Symbol value="angle" />
+    </Dynamo.Nodes.Output>
+    <Dynamo.Nodes.Output guid="83ee1aef-f798-4e80-8bef-4ac8b8479804" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="377.76582968237" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+      <Symbol value="hasRotation" />
     </Dynamo.Nodes.Output>
   </Elements>
   <Connectors>
@@ -104,12 +117,14 @@ OUT = (pointlist,curvepointlist,curves,ispoint,iscurve,haslocation)</Script>
     <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="3" end="9c5fe234-6333-42d1-8497-fa4ae9ff0a2d" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="4" end="21d34519-3cea-4d3f-b917-cbe99953d0f1" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="5" end="f049edbf-dc90-4d9d-8d55-aec33858083d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="6" end="14d49b05-5d40-4fbf-b0e4-71bfaaee0839" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="7" end="83ee1aef-f798-4e80-8bef-4ac8b8479804" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="f9cf6ebe-4cb6-43a4-b682-f29bf6633963" start_index="0" end="bd3f39ee-762e-4a88-a57d-373694197124" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Hintergrundvorschau" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" />
+    <Camera Name="background_preview" eyeX="42.2068356324358" eyeY="52.6713840367347" eyeZ="-56.2782196691706" lookX="-11.2" lookY="-11.2" lookZ="-11.2" />
   </Cameras>
 </Workspace>

--- a/nodes/0.8.x/ElementType.Duplicate.dyf
+++ b/nodes/0.8.x/ElementType.Duplicate.dyf
@@ -6,27 +6,39 @@
 clr.AddReference('RevitAPI')
 from Autodesk.Revit.DB import *
 
-clr.AddReference("RevitNodes")
+clr.AddReference('RevitNodes')
 import Revit
 clr.ImportExtensions(Revit.Elements)
 
-clr.AddReference("RevitServices")
+clr.AddReference('RevitServices')
 import RevitServices
 from RevitServices.Persistence import DocumentManager
 from RevitServices.Transactions import TransactionManager
 
 doc = DocumentManager.Instance.CurrentDBDocument
-famtypes = UnwrapElement(IN[0])
+famtypes = IN[0]
 newnames = IN[1]
-elementlist = list()
-counter = 0
+elementlist, fail = [],[] #better to generate a fail list only once
+func_enum = {'Revit.Elements.WallType' : Revit.Elements.WallType.ByName,
+			 'Revit.Elements.FloorType' : Revit.Elements.FloorType.ByName,
+			 'Revit.Elements.FamilyType' : Revit.Elements.FamilyType.ByName,
+			 'Revit.Elements.FamilySymbol' : Revit.Elements.FamilySymbol.ByName}
+			 #0.9+ renamed the FamilySymbol class to FamilyType this supports both versions
+
 TransactionManager.Instance.EnsureInTransaction(doc)
-for item in famtypes:
+for i in xrange(len(famtypes) ):
 	try:
-		elementlist.append(item.Duplicate(newnames[counter]))
+		elementlist.append(UnwrapElement(famtypes[i]).Duplicate(newnames[i]) )
 	except:
-		elementlist.append(list())
-	counter += 1
+		try:
+			t1 = famtypes[i].GetType().ToString()
+			if t1 in func_enum:
+				elementlist.append(func_enum[t1](newnames[i]) )
+			else:
+				elementlist.append(fail)
+		except:
+			elementlist.append(fail)
+
 TransactionManager.Instance.TransactionTaskDone()
 OUT = elementlist</Script>
     </DSIronPythonNode.PythonNode>

--- a/nodes/0.8.x/List.DropLastItem.dyf
+++ b/nodes/0.8.x/List.DropLastItem.dyf
@@ -1,14 +1,14 @@
-<Workspace Version="0.8.2.2392" X="30" Y="379.80841958042" zoom="1.73706293706294" Name="List.DropLastItem" Description="Drops the last item from a given list." ID="43df6cfe-4f8f-42e9-8996-43441bebd19d" Category="Clockwork.Core.List.Actions">
+<Workspace Version="0.8.2.2392" X="5.74329602678171" Y="331.41766809196" zoom="1.05042163509616" Name="List.DropLastItem" Description="Drops the last item from a given list." ID="43df6cfe-4f8f-42e9-8996-43441bebd19d" Category="Clockwork.Core.List.Actions">
   <NamespaceResolutionMap>
     <ClassMap partialName="List" resolvedName="DSCore.List" assemblyName="DSCoreNodes.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="c3f8c940-0801-413d-b81c-ea339623adcb" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="4.21333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="List.TakeItems(seq,List.Count(seq)-1);" ShouldFocus="false" />
-    <Dynamo.Nodes.Symbol guid="6982781c-2880-4df3-a7bf-4795c0d5255b" type="Dynamo.Nodes.Symbol" nickname="Input" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
-      <Symbol value="seq" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="c3f8c940-0801-413d-b81c-ea339623adcb" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="4.21333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="List.DropItems(l1,-1);" ShouldFocus="false" />
+    <Dynamo.Nodes.Symbol guid="6982781c-2880-4df3-a7bf-4795c0d5255b" type="Dynamo.Nodes.Symbol" nickname="Input" x="22.086369153922" y="-0.761598936342182" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <Symbol value="list:var[]" />
     </Dynamo.Nodes.Symbol>
-    <Dynamo.Nodes.Output guid="8c9d0709-c45c-4454-be58-4c0d070a69f1" type="Dynamo.Nodes.Output" nickname="Output" x="649" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
-      <Symbol value="seq" />
+    <Dynamo.Nodes.Output guid="8c9d0709-c45c-4454-be58-4c0d070a69f1" type="Dynamo.Nodes.Output" nickname="Output" x="438.79869356957" y="2.28479680902643" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+      <Symbol value="list" />
     </Dynamo.Nodes.Output>
   </Elements>
   <Connectors>
@@ -19,6 +19,6 @@
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+    <Camera Name="background_preview" eyeX="42.2068356324358" eyeY="52.6713840367347" eyeZ="-56.2782196691706" lookX="-11.2" lookY="-11.2" lookZ="-11.2" />
   </Cameras>
 </Workspace>

--- a/nodes/0.9.x/Element.Location.dyf
+++ b/nodes/0.9.x/Element.Location.dyf
@@ -1,4 +1,4 @@
-<Workspace Version="0.8.2.2392" X="108.149719091363" Y="186.645442473688" zoom="0.637154578399209" Name="Element.Location" Description="Returns the location of an element as an XYZ (or if it's line-based the start and end point of the line), along with some booleans to help filtering the results. Use this for some element types (e.g. walls or lines) that do not work with the built-in Get Family Instance Location node. " ID="0b59c4d8-afe4-4063-bf7e-2195fa33e8a9" Category="Clockwork.Revit.Elements.Element.Query">
+<Workspace Version="0.8.2.2392" X="-810.991792148763" Y="-102.302014787487" zoom="1.39028218019753" Name="Element.Location" Description="Returns the location of an element as an XYZ (or if it's line-based the start and end point of the line), along with some booleans to help filtering the results. Use this for some element types (e.g. walls or lines) that do not work with the built-in Get Family Instance Location node. " ID="0b59c4d8-afe4-4063-bf7e-2195fa33e8a9" Category="Clockwork.Revit.Elements.Element.Query">
   <NamespaceResolutionMap />
   <Elements>
     <Dynamo.Nodes.Function guid="0172cd21-9f9a-4382-82cb-a6341dcc77da" type="Dynamo.Nodes.Function" nickname="TurnIntoList" x="199" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
@@ -6,7 +6,7 @@
       <Name value="Turn Into List" />
       <Description value="Turns an element (or a nested list) into a flat list" />
       <Inputs>
-        <Input value="" />
+        <Input value="unknownItem" />
       </Inputs>
       <Outputs>
         <Output value="seq" />
@@ -15,24 +15,25 @@
     <Dynamo.Nodes.Symbol guid="467e3f8f-3faf-49fc-94c3-76b1b0c59c5e" type="Dynamo.Nodes.Symbol" nickname="Input" x="0" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
       <Symbol value="element" />
     </Dynamo.Nodes.Symbol>
-    <Dynamo.Nodes.Output guid="3ebf8af8-90b7-44f8-afdf-742ff53b9f65" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="3ebf8af8-90b7-44f8-afdf-742ff53b9f65" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="-13.753237059281" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="points" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="fe6d5941-e752-40bb-b243-e86bdd061ab9" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="83" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="fe6d5941-e752-40bb-b243-e86bdd061ab9" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="42.1780581895263" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="curveEndpoints" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="fef50bd5-ee46-46bb-bc91-c1d356b52c80" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="166" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="fef50bd5-ee46-46bb-bc91-c1d356b52c80" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="98.1093534383336" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="curves" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="9c5fe234-6333-42d1-8497-fa4ae9ff0a2d" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="250" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="9c5fe234-6333-42d1-8497-fa4ae9ff0a2d" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="154.040648687141" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="isPoint" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.Output guid="21d34519-3cea-4d3f-b917-cbe99953d0f1" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="21d34519-3cea-4d3f-b917-cbe99953d0f1" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="209.971943935948" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="isCurve" />
     </Dynamo.Nodes.Output>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="bd3f39ee-762e-4a88-a57d-373694197124" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="628" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="seq[0];&#xA;seq[1];&#xA;seq[2];&#xA;seq[3];&#xA;seq[4];&#xA;seq[5];" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="bd3f39ee-762e-4a88-a57d-373694197124" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="551.355185870988" y="139.870950208536" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="seq[0];&#xA;seq[1];&#xA;seq[2];&#xA;seq[3];&#xA;seq[4];&#xA;seq[5];&#xA;seq[6];&#xA;seq[7];" ShouldFocus="false" />
     <DSIronPythonNode.PythonNode guid="f9cf6ebe-4cb6-43a4-b682-f29bf6633963" type="DSIronPythonNode.PythonNode" nickname="Python Script" x="404" y="136" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" inputcount="1">
       <Script>import clr
+import math
 clr.AddReference('RevitAPI')
 from Autodesk.Revit.DB import *
 
@@ -47,6 +48,7 @@ ispoint = list()
 iscurve = list()
 curves = list()
 haslocation = list()
+angles, hasrotation = [], []
 
 for item in items:
 	try:
@@ -55,6 +57,7 @@ for item in items:
 		ispoint.append(True)
 		iscurve.append(False)
 		haslocation.append(True)
+		hasrotation.append(False)
 	except:
 		try:
 			loc = item.Location
@@ -66,12 +69,16 @@ for item in items:
 				ispoint.append(False)
 				iscurve.append(True)
 				haslocation.append(True)
+				hasrotation.append(False)
 			elif loc.ToString() == 'Autodesk.Revit.DB.LocationPoint':
 				# point-based elements
 				pointlist.append(loc.Point.ToPoint())
+				angles.append(math.degrees(loc.Rotation) )
 				ispoint.append(True)
 				iscurve.append(False)
+				angles.append
 				haslocation.append(True)
+				hasrotation.append(True)
 			else:
 				ispoint.append(False)
 				iscurve.append(False)
@@ -89,10 +96,16 @@ for item in items:
 				ispoint.append(False)
 				iscurve.append(False)
 				haslocation.append(False)
-OUT = (pointlist,curvepointlist,curves,ispoint,iscurve,haslocation)</Script>
+OUT = (pointlist,curvepointlist,curves,ispoint,iscurve,haslocation,angles, hasrotation)</Script>
     </DSIronPythonNode.PythonNode>
-    <Dynamo.Nodes.Output guid="f049edbf-dc90-4d9d-8d55-aec33858083d" type="Dynamo.Nodes.Output" nickname="Output" x="846" y="416" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+    <Dynamo.Nodes.Output guid="f049edbf-dc90-4d9d-8d55-aec33858083d" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="265.903239184756" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
       <Symbol value="hasLocation" />
+    </Dynamo.Nodes.Output>
+    <Dynamo.Nodes.Output guid="14d49b05-5d40-4fbf-b0e4-71bfaaee0839" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="321.834534433563" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+      <Symbol value="angle" />
+    </Dynamo.Nodes.Output>
+    <Dynamo.Nodes.Output guid="83ee1aef-f798-4e80-8bef-4ac8b8479804" type="Dynamo.Nodes.Output" nickname="Output" x="829.411443410782" y="377.76582968237" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+      <Symbol value="hasRotation" />
     </Dynamo.Nodes.Output>
   </Elements>
   <Connectors>
@@ -104,12 +117,14 @@ OUT = (pointlist,curvepointlist,curves,ispoint,iscurve,haslocation)</Script>
     <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="3" end="9c5fe234-6333-42d1-8497-fa4ae9ff0a2d" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="4" end="21d34519-3cea-4d3f-b917-cbe99953d0f1" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="5" end="f049edbf-dc90-4d9d-8d55-aec33858083d" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="6" end="14d49b05-5d40-4fbf-b0e4-71bfaaee0839" end_index="0" portType="0" />
+    <Dynamo.Models.ConnectorModel start="bd3f39ee-762e-4a88-a57d-373694197124" start_index="7" end="83ee1aef-f798-4e80-8bef-4ac8b8479804" end_index="0" portType="0" />
     <Dynamo.Models.ConnectorModel start="f9cf6ebe-4cb6-43a4-b682-f29bf6633963" start_index="0" end="bd3f39ee-762e-4a88-a57d-373694197124" end_index="0" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Hintergrundvorschau" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" />
+    <Camera Name="background_preview" eyeX="42.2068356324358" eyeY="52.6713840367347" eyeZ="-56.2782196691706" lookX="-11.2" lookY="-11.2" lookZ="-11.2" />
   </Cameras>
 </Workspace>

--- a/nodes/0.9.x/ElementType.Duplicate.dyf
+++ b/nodes/0.9.x/ElementType.Duplicate.dyf
@@ -6,27 +6,39 @@
 clr.AddReference('RevitAPI')
 from Autodesk.Revit.DB import *
 
-clr.AddReference("RevitNodes")
+clr.AddReference('RevitNodes')
 import Revit
 clr.ImportExtensions(Revit.Elements)
 
-clr.AddReference("RevitServices")
+clr.AddReference('RevitServices')
 import RevitServices
 from RevitServices.Persistence import DocumentManager
 from RevitServices.Transactions import TransactionManager
 
 doc = DocumentManager.Instance.CurrentDBDocument
-famtypes = UnwrapElement(IN[0])
+famtypes = IN[0]
 newnames = IN[1]
-elementlist = list()
-counter = 0
+elementlist, fail = [],[] #better to generate a fail list only once
+func_enum = {'Revit.Elements.WallType' : Revit.Elements.WallType.ByName,
+			 'Revit.Elements.FloorType' : Revit.Elements.FloorType.ByName,
+			 'Revit.Elements.FamilyType' : Revit.Elements.FamilyType.ByName,
+			 'Revit.Elements.FamilySymbol' : Revit.Elements.FamilySymbol.ByName}
+			 #0.9+ renamed the FamilySymbol class to FamilyType this supports both versions
+
 TransactionManager.Instance.EnsureInTransaction(doc)
-for item in famtypes:
+for i in xrange(len(famtypes) ):
 	try:
-		elementlist.append(item.Duplicate(newnames[counter]))
+		elementlist.append(UnwrapElement(famtypes[i]).Duplicate(newnames[i]) )
 	except:
-		elementlist.append(list())
-	counter += 1
+		try:
+			t1 = famtypes[i].GetType().ToString()
+			if t1 in func_enum:
+				elementlist.append(func_enum[t1](newnames[i]) )
+			else:
+				elementlist.append(fail)
+		except:
+			elementlist.append(fail)
+
 TransactionManager.Instance.TransactionTaskDone()
 OUT = elementlist</Script>
     </DSIronPythonNode.PythonNode>

--- a/nodes/0.9.x/List.DropLastItem.dyf
+++ b/nodes/0.9.x/List.DropLastItem.dyf
@@ -1,14 +1,14 @@
-<Workspace Version="0.8.2.2392" X="30" Y="379.80841958042" zoom="1.73706293706294" Name="List.DropLastItem" Description="Drops the last item from a given list." ID="43df6cfe-4f8f-42e9-8996-43441bebd19d" Category="Clockwork.Core.List.Actions">
+<Workspace Version="0.8.2.2392" X="5.74329602678171" Y="331.41766809196" zoom="1.05042163509616" Name="List.DropLastItem" Description="Drops the last item from a given list." ID="43df6cfe-4f8f-42e9-8996-43441bebd19d" Category="Clockwork.Core.List.Actions">
   <NamespaceResolutionMap>
     <ClassMap partialName="List" resolvedName="DSCore.List" assemblyName="DSCoreNodes.dll" />
   </NamespaceResolutionMap>
   <Elements>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="c3f8c940-0801-413d-b81c-ea339623adcb" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="4.21333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="List.TakeItems(seq,List.Count(seq)-1);" ShouldFocus="false" />
-    <Dynamo.Nodes.Symbol guid="6982781c-2880-4df3-a7bf-4795c0d5255b" type="Dynamo.Nodes.Symbol" nickname="Input" x="0" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
-      <Symbol value="seq" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="c3f8c940-0801-413d-b81c-ea339623adcb" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="166" y="4.21333333333333" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="List.DropItems(l1,-1);" ShouldFocus="false" />
+    <Dynamo.Nodes.Symbol guid="6982781c-2880-4df3-a7bf-4795c0d5255b" type="Dynamo.Nodes.Symbol" nickname="Input" x="22.086369153922" y="-0.761598936342182" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True">
+      <Symbol value="list:var[]" />
     </Dynamo.Nodes.Symbol>
-    <Dynamo.Nodes.Output guid="8c9d0709-c45c-4454-be58-4c0d070a69f1" type="Dynamo.Nodes.Output" nickname="Output" x="649" y="0" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
-      <Symbol value="seq" />
+    <Dynamo.Nodes.Output guid="8c9d0709-c45c-4454-be58-4c0d070a69f1" type="Dynamo.Nodes.Output" nickname="Output" x="438.79869356957" y="2.28479680902643" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False">
+      <Symbol value="list" />
     </Dynamo.Nodes.Output>
   </Elements>
   <Connectors>
@@ -19,6 +19,6 @@
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="background_preview" eyeX="10" eyeY="15" eyeZ="10" lookX="-10" lookY="-10" lookZ="-10" />
+    <Camera Name="background_preview" eyeX="42.2068356324358" eyeY="52.6713840367347" eyeZ="-56.2782196691706" lookX="-11.2" lookY="-11.2" lookZ="-11.2" />
   </Cameras>
 </Workspace>


### PR DESCRIPTION
### Purpose
This PR extends the existing functionality of the "ElementType.Duplicate" node to enable workflows that try to define a type multiple times
The current behavior:
![2016-05-06_17-56-57](https://cloud.githubusercontent.com/assets/7148394/15070745/e025de9e-13b8-11e6-8868-d62e903b37e1.png)

### Changes
Uses the built-in Dynamo methods to fetch already defined types. This eliminates the need to run collectors inside the python interpreter.
The new behavior:
![2016-05-06_18-18-21](https://cloud.githubusercontent.com/assets/7148394/15070752/ebe33ccc-13b8-11e6-8e9a-bef21a698f09.png)

### Housekeeping
Please **make sure these boxes are checked** before submitting your issue:
- [x] I am running one of the *supported* Clockwork versions
- [x] I am running the *latest available version* of Clockwork
- [x] No submitted 0.8 node has been authored in a post-0.8.2 build
- [x] No submitted 0.9 node has been authored in a post-0.9.0 build

Please check this box if applicable
- [x] This pull request contains code for *all supported versions* of Clockwork