### PR TITLE
Update Category.FromInput.dyf

### DIFF
--- a/nodes/2.x/Category.FromInput.dyf
+++ b/nodes/2.x/Category.FromInput.dyf
@@ -13,7 +13,7 @@
     {
       "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
       "NodeType": "PythonScriptNode",
-      "Code": "import System\r\nimport clr\r\nclr.AddReference('RevitAPI')\r\nfrom Autodesk.Revit.DB import *\r\n\r\nclr.AddReference(\"RevitNodes\")\r\nimport Revit\r\nclr.ImportExtensions(Revit.Elements)\r\n\r\nclr.AddReference(\"RevitServices\")\r\nimport RevitServices\r\nfrom RevitServices.Persistence import DocumentManager\r\n\r\ndoc = DocumentManager.Instance.CurrentDBDocument\r\nbics = System.Enum.GetValues(BuiltInCategory)\r\ncats = UnwrapElement(IN[0])\r\n\r\nif not hasattr(cats,\"__iter__\"):\r\n\tcats = [cats]\r\n\r\noutput = []\r\n\r\nfor cat in cats:\r\n\tcattype = cat.GetType().ToString()\r\n\tif cattype == \"Autodesk.Revit.DB.Category\": output.append(cat)\r\n\telif  cattype == \"Autodesk.Revit.DB.BuiltInCategory\": output.append(Category.GetCategory(doc, cat))\r\n\telif cattype == \"System.String\": \r\n\t\t\tfound = [x for x in bics if x.ToString() == cat]\r\n\t\t\tif len(found) > 0: output.append( Category.GetCategory(doc, found[0]))\r\nOUT = output",
+      "Code": "import System\r\nimport clr\r\nclr.AddReference('RevitAPI')\r\nfrom Autodesk.Revit.DB import *\r\n\r\nclr.AddReference(\"RevitNodes\")\r\nimport Revit\r\nclr.ImportExtensions(Revit.Elements)\r\n\r\nclr.AddReference(\"RevitServices\")\r\nimport RevitServices\r\nfrom RevitServices.Persistence import DocumentManager\r\n\r\ndef GetCatFromInput(var):\t\r\n\tif var:\r\n\t\tcattype = var.GetType().ToString()\r\n\t\tif cattype == \"Autodesk.Revit.DB.Category\": return var\r\n\t\telif cattype == \"Autodesk.Revit.DB.BuiltInCategory\": return Category.GetCategory(doc, var)\r\n\t\telif cattype == \"System.String\": \r\n\t\t\tfound = [x for x in bics if x.ToString() == var]\r\n\t\t\tif len(found) > 0: return Category.GetCategory(doc, found[0])\t\t\r\n\telse: \r\n\t\treturn None\r\n\r\ndoc = DocumentManager.Instance.CurrentDBDocument\r\nbics = System.Enum.GetValues(BuiltInCategory)\r\ncats = UnwrapElement(IN[0])\r\n\r\nif isinstance(IN[0], list): OUT = [GetCatFromInput(x) for x in cats]\r\nelse: OUT = GetCatFromInput(cats)",
       "VariableInputPorts": true,
       "Id": "f6f1249cad3f4e4ab05b14e7eeaecc45",
       "Inputs": [
@@ -133,8 +133,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 212.5,
-        "Y": -18.0
+        "X": 214.5,
+        "Y": 0.0
       },
       {
         "ShowGeometry": true,
@@ -158,8 +158,8 @@
       }
     ],
     "Annotations": [],
-    "X": 215.0,
-    "Y": 47.0,
-    "Zoom": 1.0
+    "X": -27.203561188450919,
+    "Y": 85.806429524482056,
+    "Zoom": 1.4761802392636134
   }
 }

--- a/nodes/2.x/Category.FromInput.dyf
+++ b/nodes/2.x/Category.FromInput.dyf
@@ -13,7 +13,7 @@
     {
       "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
       "NodeType": "PythonScriptNode",
-      "Code": "import System\r\nimport clr\r\nclr.AddReference('RevitAPI')\r\nfrom Autodesk.Revit.DB import *\r\n\r\nclr.AddReference(\"RevitNodes\")\r\nimport Revit\r\nclr.ImportExtensions(Revit.Elements)\r\n\r\nclr.AddReference(\"RevitServices\")\r\nimport RevitServices\r\nfrom RevitServices.Persistence import DocumentManager\r\n\r\ndef GetCatFromInput(var):\t\r\n\tcat = None\r\n\tif var:\r\n\t\tcattype = var.GetType().ToString()\r\n\t\tif cattype == \"Autodesk.Revit.DB.Category\": cat = var\r\n\t\telif cattype == \"Autodesk.Revit.DB.BuiltInCategory\": cat = Category.GetCategory(doc, var)\r\n\t\telif cattype == \"System.String\": \r\n\t\t\tfound = [x for x in bics if x.ToString() == var]\r\n\t\t\tif len(found) > 0: cat = Category.GetCategory(doc, found[0])\r\n\treturn cat\r\n\r\ndoc = DocumentManager.Instance.CurrentDBDocument\r\nbics = System.Enum.GetValues(BuiltInCategory)\r\ncats = UnwrapElement(IN[0])\r\n\r\nif isinstance(IN[0], list): OUT = [GetCatFromInput(x) for x in cats]\r\nelse: OUT = GetCatFromInput(cats)",
+      "Code": "import System\r\nimport clr\r\nclr.AddReference('RevitAPI')\r\nfrom Autodesk.Revit.DB import *\r\n\r\nclr.AddReference(\"RevitNodes\")\r\nimport Revit\r\nclr.ImportExtensions(Revit.Elements)\r\n\r\nclr.AddReference(\"RevitServices\")\r\nimport RevitServices\r\nfrom RevitServices.Persistence import DocumentManager\r\n\r\ndoc = DocumentManager.Instance.CurrentDBDocument\r\nbics = System.Enum.GetValues(BuiltInCategory)\r\ncats = UnwrapElement(IN[0])\r\n\r\nif not hasattr(cats,\"__iter__\"):\r\n\tcats = [cats]\r\n\r\noutput = []\r\n\r\nfor cat in cats:\r\n\tcattype = cat.GetType().ToString()\r\n\tif cattype == \"Autodesk.Revit.DB.Category\": output.append(cat)\r\n\telif  cattype == \"Autodesk.Revit.DB.BuiltInCategory\": output.append(Category.GetCategory(doc, cat))\r\n\telif cattype == \"System.String\": \r\n\t\t\tfound = [x for x in bics if x.ToString() == cat]\r\n\t\t\tif len(found) > 0: output.append( Category.GetCategory(doc, found[0]))\r\nOUT = output",
       "VariableInputPorts": true,
       "Id": "f6f1249cad3f4e4ab05b14e7eeaecc45",
       "Inputs": [
@@ -102,13 +102,14 @@
     }
   ],
   "Dependencies": [],
+  "NodeLibraryDependencies": [],
   "Bindings": [],
   "View": {
     "Dynamo": {
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": false,
       "IsVisibleInDynamoLibrary": false,
-      "Version": "2.0.4.12684",
+      "Version": "2.3.1.11775",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },
@@ -132,8 +133,8 @@
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
         "Excluded": false,
-        "X": 214.5,
-        "Y": 0.0
+        "X": 212.5,
+        "Y": -18.0
       },
       {
         "ShowGeometry": true,


### PR DESCRIPTION
Diese Node bringt Dynamo zum Absturz. Wenn man ein Skript einmal laufen lässt, produziert die Node keinen Fehler aber beim zweiten Lauf kommt ein Fehler auf. Das liegt wahrscheinlich an cat = None. Im Hintergrund wird beim zweiten Mal null-Wert angenommen. Ich habe den Code angepasst. Nun funktioniert es.
Document.ProjectParametersByCategory is davon betroffen.

### Purpose
(Please fill in and add screenshots if applicable)

### Changes
(Please fill in and add screenshots if applicable)

### Housekeeping
- [x] I am running the *latest available version* of Clockwork
